### PR TITLE
Update to bookworm-slim

### DIFF
--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -20,4 +20,4 @@ jobs:
         fetch-depth: 0
     - uses: docker://dkhamsing/awesome_bot:latest
       with:
-        args: /github/workspace/README.md --allow-ssl --allow 202,500,501,502,503,504,509,521 --allow-dupe --allow-redirect --request-delay 1 --white-list https://github,https://img.shields.io,https://twitter.com,https://medium.com,https://stackoverflow.com,http://hostname:631,https://cups.org
+        args: /github/workspace/README.md --allow-ssl --allow 202,500,501,502,503,504,509,521 --allow-dupe --allow-redirect --request-delay 1 --white-list https://github,https://img.shields.io,https://twitter.com,https://medium.com,https://stackoverflow.com,https://cups.org,http://hostname:631,http://cupsd-hostname:631

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
 LABEL description="Cupsd on top of debian-slim"
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@
 
 `cupsd` in a docker container.
 
-Based on bullseye-slim. Includes [cupsd](https://cups.org) along with every printer driver I could think of.
+Based on debian:bullseye-slim. Includes [cupsd](https://cups.org) along with every printer driver I could think of.
 
-Admin user & passwords default to print/print
+Admin user & passwords default to **print** / **print**
 
 ## Run the server
 
 Start `cupsd` with:
 
-```
+```sh
 sudo docker run -d --restart unless-stopped \
   -p 631:631 \
   --privileged \
@@ -55,16 +55,14 @@ Mounting `printers.conf` into the container keeps you from losing your printer c
 
 ## Add printers to server
 
-1. Connect to `http://hostname:631`
-2. Adminstration -> Printers -> Add Printer
+1. Connect to `http://cupsd-hostname:631`
+2. **Adminstration** -> **Printers** -> **Add Printer**
 
 ## Add the printer to your Mac
 
-1. System Preferences -> Printers
-2. Click on the +
+1. **System Preferences** -> **Printers**
+2. Click on the **+**
 3. Click the center sphere icon
 4. Put the IP (or better, DNS name) of your server in the Address field
-5. Select Internet Printing Protocol in the Protocol dropdown
+5. Select `Internet Printing Protocol` in the Protocol dropdown
 6. Put `printers/YOURPRINTERNAME` in the queue field.
-
-Edit - add job retries

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ task :build => [:multiarch_build]
 task :buildx => [:multiarch_build]
 
 CONTAINER_NAME = 'unixorn/cupsd'
+BASELINE = 'bookworm-slim'
 
 task :usage do
   puts 'Usage:'
@@ -18,21 +19,25 @@ end
 
 desc 'Use buildx to make a multi-arch container without cache'
 task :cacheless do
-  puts "Building #{CONTAINER_NAME}"
+  puts "Building #{CONTAINER_NAME}:#{BASELINE}"
+  sh %{ docker buildx build --no-cache --platform linux/amd64,linux/arm/v7,linux/arm64 --push -t #{CONTAINER_NAME}:#{BASELINE} .}
   sh %{ docker buildx build --no-cache --platform linux/amd64,linux/arm/v7,linux/arm64 --push -t #{CONTAINER_NAME} .}
   sh %{ docker pull #{CONTAINER_NAME} }
+  sh %{ docker pull #{CONTAINER_NAME}#{BASELINE} }
 end
 
 desc 'Use buildx to make a multi-arch container'
 task :multiarch_build do
-  puts "Building #{CONTAINER_NAME}"
+  puts "Building #{CONTAINER_NAME}:#{BASELINE}"
   sh %{ docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 --push -t #{CONTAINER_NAME} .}
+  sh %{ docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 --push -t #{CONTAINER_NAME}:#{BASELINE} .}
   sh %{ docker pull #{CONTAINER_NAME} }
 end
 
 desc 'Buildx a local multiarch container'
 task :local_multiarch_build do
-  puts "Building #{CONTAINER_NAME}"
+  puts "Building #{CONTAINER_NAME}:#{BASELINE}"
+  sh %{ docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 --load -t #{CONTAINER_NAME}:#{BASELINE} .}
   sh %{ docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 --load -t #{CONTAINER_NAME} .}
 end
 


### PR DESCRIPTION
Moved `cupsd` to a different host in my homelab and realized it was still running on `debian:bullseye-slim`.

Update to build on top of `debian:bookworm-slim`